### PR TITLE
typo corrections

### DIFF
--- a/README
+++ b/README
@@ -4,8 +4,8 @@ Net-DHCP version 0.66
 0. DOCS/ FILES WARNING
 ----------------------
 
-Some files in the docs/ directory are copied from iana. 
-They may not be compatible with the Perl license. I have 
+Some files in the docs/ directory are copied from IANA.
+They may not be compatible with the Perl license. I have
 included them in the tar ball as-is for the sake of reference.
 Please remove them if needed for distribution packaging etc.
 

--- a/lib/Net/DHCP/Constants.pm
+++ b/lib/Net/DHCP/Constants.pm
@@ -87,7 +87,7 @@ BEGIN {
         'HTYPE_FDDI'    => 8
     );
 
-    %DHO_CODES = (    # rfc 2132
+    %DHO_CODES = (    # RFC 2132
         'DHO_PAD'                                  => 0,
         'DHO_SUBNET_MASK'                          => 1,
         'DHO_TIME_OFFSET'                          => 2,
@@ -154,7 +154,7 @@ BEGIN {
         'DHO_NWIP_SUBOPTIONS'                      => 63,
         'DHO_NISV3_DOMAIN'                         => 64,
         'DHO_NISV3_SERVER'                         => 65,
-        'DHO_TFTP_SERVER'                          => 66, # actually named 'server name' by iana
+        'DHO_TFTP_SERVER'                          => 66, # actually named 'server name' by IANA
         'DHO_BOOTFILE'                             => 67,
         'DHO_MOBILE_IP_HOME_AGENT'                 => 68,
         'DHO_SMTP_SERVER'                          => 69,
@@ -344,8 +344,8 @@ use constant \%RELAYAGENT_CODES;
 # Format of DHCP options : for pretty-printing
 #   void : no parameter
 #   inet : 4 bytes IP address
-#   inets : list of 4 bytess IP addresses
-#   inets2 : liste of 4 bytes IP addresses pairs (multiple of 8 bytes)
+#   inets : list of 4 bytes IP addresses
+#   inets2 : list of 4 bytes IP addresses pairs (multiple of 8 bytes)
 #   int : 4 bytes integer
 #   short : 2 bytes integer
 #   shorts : list of 2 bytes integers
@@ -531,7 +531,7 @@ Import all DHCP Message codes.
 
 Nb. Previously Cisco used 13 for DHCPLEASEQUERY. If you need to decode
 or encode packets to communicate with such a system, you might simply
-us the integer rather than the constant - or use the updated constant
+use the integer rather than the constant - or use the updated constant
 and comment in your code appropriately.
 
 =item * dho_codes

--- a/lib/Net/DHCP/Packet.pm
+++ b/lib/Net/DHCP/Packet.pm
@@ -1102,7 +1102,7 @@ To create a fresh new packet C<new()> takes arguments as a key-value pairs :
                                See Net::DHCP::Constants.
    Padding    padding       *  Optional padding at the end of the packet
 
-See below methods for values and syntax descrption.
+See below methods for values and syntax description.
 
 Note: DHCP options are created in the same order as key-value pairs.
 
@@ -1201,7 +1201,7 @@ See L<Special methods> below.
 
 Sets/gets the I<client hardware address>. Its length is given by the C<hlen> attribute.
 
-Valude is formatted as an Hexadecimal string representation.
+Value is formatted as an Hexadecimal string representation.
 
   Example: "0010A706DFFF" for 6 bytes mac address.
 
@@ -1257,7 +1257,7 @@ depending on their format as defined by RFC 2132.
 Please see L<DHCP OPTION TYPES> for supported options and corresponding
 formats.
 
-If you nedd access to the raw binary values, please use C<addOptionRaw()>.
+If you need access to the raw binary values, please use C<addOptionRaw()>.
 
    $pac = Net::DHCP::Packet->new();
    $pac->addOption(DHO_DHCP_MESSAGE_TYPE(), DHCPINFORM());
@@ -1273,7 +1273,7 @@ depending on their format as defined by RFC 2132.
 Please see L<DHCP OPTION TYPES> for supported options and corresponding
 formats.
 
-If you nedd access to the raw binary values, please use C<addSubOptionRaw()>.
+If you need access to the raw binary values, please use C<addSubOptionRaw()>.
 
    $pac = Net::DHCP::Packet->new();
    # FIXME update exampls
@@ -1290,7 +1290,7 @@ as defined in RFC 2132.
 Please see L<DHCP OPTION TYPES> for supported options and corresponding
 formats.
 
-If you nedd access to the raw binary values, please use C<getOptionRaw()>.
+If you need access to the raw binary values, please use C<getOptionRaw()>.
 
 Return value is either a string or an array, depending on the context.
 
@@ -1344,7 +1344,7 @@ C<decodeRelayAgent>
 
 =item I packcsr( ARRAYREF )
 
-returns the packed Classless Static Route option built from a list of cidr style address/mask combos
+returns the packed Classless Static Route option built from a list of CIDR style address/mask combos
 
 =item I<unpackcsr>
 
@@ -1362,7 +1362,7 @@ I<Removed as of version 0.60. Please use C<getOptionRaw()> instead.>
 
 =head2 DHCP OPTIONS TYPES
 
-This section describes supported option types (cf. rfc 2132).
+This section describes supported option types (cf. RFC 2132).
 
 For unsupported data types, please use C<getOptionRaw()> and
 C<addOptionRaw> to manipulate binary format directly.
@@ -1586,12 +1586,12 @@ Transforms a packed bytes IP address into a "xx.xx.xx.xx" string.
 
 =item unpackinets ( STRING )
 
-Transforms a packed bytes liste of IP addresses into a list of
+Transforms a packed bytes list of IP addresses into a list of
 "xx.xx.xx.xx" space delimited string.
 
 =item unpackinets_array ( STRING )
 
-Transforms a packed bytes liste of IP addresses into a array of
+Transforms a packed bytes list of IP addresses into a array of
 "xx.xx.xx.xx" strings.
 
 =back


### PR DESCRIPTION
I spotted a typo somewhere so I went through the module with spellcheck turned on.  I also noticed some errors on the line regarding CableLabs in the Changes file, but since it's historical I didn't want to edit it because I don't know if that's allowed.