### PR TITLE
Added user class => string mapping 

### DIFF
--- a/lib/Net/DHCP/Constants.pm
+++ b/lib/Net/DHCP/Constants.pm
@@ -455,7 +455,9 @@ our %DHO_FORMATS = (
     DHO_CLASSLESS_STATIC_ROUTE()      => 'csr',        # rfc 3442
     DHO_CCC                           => 'suboptions', # 122
 
-#    DHO_USER_CLASS()  => '',                        # rfc 3004
+    # While not perfect, usage is primarily as a string.  iPXE is
+    # a common use case for this option.
+    DHO_USER_CLASS()                  => 'string',     # rfc 3004
 #    DHO_FQDN()  => '',                              # draft-ietf-dhc-fqdn-option-10.txt
     DHO_DHCP_AGENT_OPTIONS()           => 'suboptions', # rfc 3046
 #    DHO_DHCP_AGENT_OPTIONS()           => 'string',    # rfc 3046


### PR DESCRIPTION
Added user class => string mapping in DHO_FORMATS to avoid copious warnings.  iPXE uses the USER_CLASS option, and my dhcpd server is spewing warning.