### PR TITLE
Declare provided modules in meta.{yml,json}

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -9,6 +9,7 @@ main_module = lib/Net/DHCP.pm
 [@Filter]
 -bundle = @Basic
 -remove = Readme
+[MetaProvides::Package]
 [MetaJSON]
 [MetaTests]
 [ModuleBuild]


### PR DESCRIPTION
This was listed as an experimental issue in following URL:
https://cpants.cpanauthors.org/dist/Net-DHCP